### PR TITLE
Fix isFinite example

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@
 * Underscore
 
   ```javascript
-  _.isFinite(object)
+  _.isNumber(object) && _.isFinite(object)
   ```
 
 * ES2015


### PR DESCRIPTION
Make Underscore example analogous to `Number.isFinite`. `_.isFinite` coerces the argument to number, so an additional check is needed.
