### PR TITLE
`const` is ES2015?

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,13 +406,13 @@
 * Underscore
 
   ```javascript
-  const fun = _.constant(value);
+  var FUN = _.constant(value);
   ```
 
 * ES2015
 
   ```javascript
-  const fun = () => value;
+  const FUN = () => value;
   ```
 
 #### The empty function


### PR DESCRIPTION
I think `const` was officially part of ES2015, not ES5, but a few browsers were ahead of their time.
http://stackoverflow.com/questions/130396/are-there-constants-in-javascript
Also caps for good practice.
