### PR TITLE
Updated range to remove redundant k param

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@
 * ES2015
 
   ```javascript
-  Array.from(Array(n), (v, k) => k + x)
+  Array.from(Array(n), (_, i) => x + i)
   ```
 
 ### Objects


### PR DESCRIPTION
Found the redundant k param distracting, like I had missed something. Instead, just use an underscore '_' to indicate you don't care about that param.

Curiously, in addition, this might interest you.

Couple of alternatives:

```
Array(n).fill().map((_,i) => x + i)
Array.from(Array(n), (_, i) => x + i)
```

Demo using n = 10, x = 1:

```
> Array(10).fill().map((_,i) => i + 1)
// [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
```

```
> Array.from(Array(10), (_, i) => i + 1)
// [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
```

When I exercised each of these 1000,000 times, as part of a **repeat** function, I found the Array(n).fill() approach actually more performant too.

See my [stackoverflow answer](http://stackoverflow.com/a/34175903/1882064) related to a question regarding **repeat** functions in JS.

However, I have kept your answer for this repo, because I think it is perhaps clearer to read, and a good working example of Array.from.

To be honest, I would also say your use of rest params for the arguments, could also just have been Array.from(arguments), but this example demonstrates Array.from too.
