### PR TITLE
Added ES2015/16 alternative to _.object

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,26 @@
   [...arguments]
   ```
 
+#### Convert an object-like array to object
+
+* Underscore
+
+    ```javascript
+    _.object(array)
+    ```
+
+* ES2015
+
+    ```javascript
+    array.reduce((result, [key, val]) => Object.assign(result, {[key]: val}), {})
+    ```
+
+* ES2016
+
+    ```javascript
+    array.reduce((result, [key, val]) => {...result, [key]: val}, {})
+    ```
+
 #### Create a copy of an array with all falsy values removed
 
 * Underscore


### PR DESCRIPTION
Just rewrote a bunch of old calls to `_.object` in my codebase, so I thought I'd share this.

I don't think any of these calls were specifically in the format of `_.object(objectLikeArray)`. They were more like `_(array.map(functionToTurnIntoObject)).object()`. But this is still useful.
