### PR TITLE
Add Object.values()

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@
   Object.keys(object).map(key => object[key])
   ```
 
+* ES2017
+
+  ```javascript
+  Object.values(object)
+  ```
+
 #### Create a new object with the given prototype and properties
 
 * Underscore


### PR DESCRIPTION
We can now use Object.values() which was added in ES2017. See [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values) for usage.